### PR TITLE
Refactor/Approval

### DIFF
--- a/src/modules/approval/controller/approval.controller.ts
+++ b/src/modules/approval/controller/approval.controller.ts
@@ -20,6 +20,7 @@ import {
   ApiOperation,
   ApiQuery,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import {
   APPROVAL_ERROR_MESSAGE as AEM,
@@ -29,7 +30,6 @@ import {
   AcceptApprovalDto,
   CreateApprovalDto,
   FetchDoctorApprovalsDto,
-  FindApprovalDto,
   RejectApprovalDto,
 } from '../dto/approval.dto';
 import { ApprovalService } from '../service/approval.service';
@@ -42,13 +42,20 @@ export class ApprovalController {
 
   @Post('createApproval')
   @UseGuards(AuthGuard, OwnerGuard)
-  @ApiOperation({ summary: 'Create a new approval' })
+  @ApiOperation({
+    summary: 'Create a new approval',
+    description:
+      "Creates a new approval request for a practitioner to access patient records. When shareHealthInfo is set to true, the patient's health information will be automatically shared with the practitioner upon approval creation. This requires the patient to have existing health information on file.",
+  })
   @ApiOkResponse({
     description: ASM.APPROVAL_CREATED,
     type: SuccessResponseDto,
     example: {
       status: HttpStatus.OK,
       message: ASM.APPROVAL_CREATED,
+      data: {
+        approvalId: 'approval-id-123',
+      },
     },
   })
   @ApiBadRequestResponse({
@@ -60,11 +67,43 @@ export class ApprovalController {
     },
   })
   @ApiBadRequestResponse({
+    description: AEM.PRACTITIONER_NOT_VERIFIED,
+    type: ErrorResponseDto,
+    example: {
+      status: HttpStatus.BAD_REQUEST,
+      message: AEM.PRACTITIONER_NOT_VERIFIED,
+    },
+  })
+  @ApiBadRequestResponse({
     description: AEM.RECORD_ID_IS_REQUIRED,
     type: ErrorResponseDto,
     example: {
       status: HttpStatus.BAD_REQUEST,
       message: AEM.RECORD_ID_IS_REQUIRED,
+    },
+  })
+  @ApiBadRequestResponse({
+    description: AEM.APPROVAL_ALREADY_EXISTS,
+    type: ErrorResponseDto,
+    example: {
+      status: HttpStatus.BAD_REQUEST,
+      message: AEM.APPROVAL_ALREADY_EXISTS,
+    },
+  })
+  @ApiUnauthorizedResponse({
+    description: AEM.PATIENT_ONLY,
+    type: ErrorResponseDto,
+    example: {
+      status: HttpStatus.UNAUTHORIZED,
+      message: AEM.PATIENT_ONLY,
+    },
+  })
+  @ApiNotFoundResponse({
+    description: AEM.HEALTH_INFO_NOT_FOUND,
+    type: ErrorResponseDto,
+    example: {
+      status: HttpStatus.NOT_FOUND,
+      message: AEM.HEALTH_INFO_NOT_FOUND,
     },
   })
   @ApiInternalServerErrorResponse({

--- a/src/modules/approval/data/approval.data.ts
+++ b/src/modules/approval/data/approval.data.ts
@@ -18,6 +18,7 @@ export enum APPROVAL_ERROR_MESSAGE {
   APPROVAL_NOT_ACCEPTED = 'Approval not accepted',
   ERROR_DELETING_APPROVAL = 'Error deleting approval',
   ERROR_FINDING_APPROVAL = 'Error finding approval',
+  HEALTH_INFO_NOT_FOUND = 'Health information not found',
 }
 
 export enum APPROVAL_SUCCESS_MESSAGE {

--- a/src/modules/approval/dto/approval.dto.ts
+++ b/src/modules/approval/dto/approval.dto.ts
@@ -1,6 +1,12 @@
 import { TAccess } from '@/modules/contract/interface/contract.interface';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+import {
+  IsBoolean,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class CreateApprovalDto {
   @ApiProperty({ description: 'User ID', example: '1234567890' })
@@ -36,6 +42,15 @@ export class CreateApprovalDto {
   @IsOptional()
   @IsString()
   accessLevel: TAccess;
+
+  @ApiPropertyOptional({
+    description: 'Whether to share health information with the practitioner',
+    example: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  shareHealthInfo?: boolean;
 }
 
 export class FetchDoctorApprovalsDto {

--- a/src/modules/contract/interface/contract.interface.ts
+++ b/src/modules/contract/interface/contract.interface.ts
@@ -36,6 +36,7 @@ export interface IHandleApproval {
   recordId?: number;
   duration?: number;
   accessLevel: TAccess;
+  shareHealthInfo?: boolean;
 }
 
 export interface IAddMedicalRecordTx {

--- a/src/schemas/schema.ts
+++ b/src/schemas/schema.ts
@@ -137,6 +137,10 @@ export const approvals = pgTable('approvals', {
   })
     .notNull()
     .references(() => accounts.smartWalletAddress, { onDelete: 'cascade' }),
+  userHealthInfoId: uuid('user_health_info_id').references(
+    () => healthInformation.id,
+    { onDelete: 'cascade' },
+  ),
   recordId: integer('recordId').default(0),
   duration: integer('duration').default(0),
   createdAt: date('created_at').notNull().defaultNow(),


### PR DESCRIPTION
This refactor extends the `createApproval` endpoint to take an additional `shareHealthInfo` `boolean` flag. when toggled approval will be sent with health info data