### PR TITLE
Feat/Health info

### DIFF
--- a/src/modules/approval/controller/approval.controller.ts
+++ b/src/modules/approval/controller/approval.controller.ts
@@ -134,6 +134,7 @@ export class ApprovalController {
           userId: 'patient-id-456',
           practitionerAddress: '0x123...abc',
           recordId: 1,
+          healthInfoId: '123455',
           duration: 3600,
           accessLevel: 'read',
           isRequestAccepted: false,

--- a/src/modules/approval/data/approval.data.ts
+++ b/src/modules/approval/data/approval.data.ts
@@ -19,6 +19,7 @@ export enum APPROVAL_ERROR_MESSAGE {
   ERROR_DELETING_APPROVAL = 'Error deleting approval',
   ERROR_FINDING_APPROVAL = 'Error finding approval',
   HEALTH_INFO_NOT_FOUND = 'Health information not found',
+  ERROR_FETCHING_APPROVAL = 'Error fetching approval',
 }
 
 export enum APPROVAL_SUCCESS_MESSAGE {

--- a/src/modules/approval/provider/approval.provider.ts
+++ b/src/modules/approval/provider/approval.provider.ts
@@ -271,6 +271,7 @@ export class ApprovalProvider {
           accessLevel: schema.approvals.accessLevel,
           isRequestAccepted: schema.approvals.isRequestAccepted,
           patientFullName: schema.user.fullName,
+          userHealthInfoId: schema.approvals.userHealthInfoId || null,
         })
         .from(schema.approvals)
         .innerJoin(schema.user, eq(schema.approvals.userId, schema.user.id))
@@ -544,6 +545,29 @@ export class ApprovalProvider {
       });
     } catch (e) {
       return this.handler.handleError(e, AEM.ERROR_DELETING_APPROVAL);
+    }
+  }
+
+  async fetchApproval(approvalId: string) {
+    try {
+      const approval = await this.db.query.approvals.findFirst({
+        where: eq(schema.approvals.id, approvalId),
+      });
+
+      if (!approval || typeof approval === undefined) {
+        return this.handler.handleReturn({
+          status: HttpStatus.NOT_FOUND,
+          message: AEM.APPROVAL_NOT_FOUND,
+        });
+      }
+
+      return this.handler.handleReturn({
+        status: HttpStatus.OK,
+        message: ASM.APPROVAL_FOUND,
+        data: approval,
+      });
+    } catch (e) {
+      return this.handler.handleError(e, AEM.ERROR_FETCHING_APPROVAL);
     }
   }
 }

--- a/src/modules/approval/service/approval.service.ts
+++ b/src/modules/approval/service/approval.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import {
   IAcceptApproval,
   IRejectApproval,
+  IValidateApprovalDuration,
   IValidatePractitionerIsApproved,
 } from '../interface/approval.interface';
 import { ApprovalProvider } from '../provider/approval.provider';
@@ -49,5 +50,13 @@ export class ApprovalService {
   @OnEvent(SharedEvents.DELETE_APPROVAL)
   async deleteApproval(ctx: EDeleteApproval) {
     return await this.approvalProvider.deleteApproval(ctx.approvalId);
+  }
+
+  async fetchApproval(approvalId: string) {
+    return await this.approvalProvider.fetchApproval(approvalId);
+  }
+
+  validateApprovalDuration(ctx: IValidateApprovalDuration) {
+    return this.approvalProvider.validateApprovalDuration(ctx);
   }
 }

--- a/src/modules/health-info/data/health-info.data.ts
+++ b/src/modules/health-info/data/health-info.data.ts
@@ -4,10 +4,16 @@ export enum HEALTH_INFO_ERROR_MESSAGES {
   HEALTH_INFO_INVALID_DATA = 'Invalid health info data',
   ERROR_CREATING_HEALTH_INFO = 'Error creating health info',
   ERROR_UPDATING_HEALTH_INFO = 'Error updating health info',
+  ERROR_FETCHING_HEALTH_INFO = 'Error fetching health info',
+  UNAUTHORIZED = 'Unauthorized',
+  APPROVAL_EXPIRED = 'Approval expired',
+  ERROR_VALIDATING_HEALTH_ACCESS = 'Error validating health access',
+  HEALTH_INFO_ACCESS_DENIED = 'Health info access denied',
 }
 
 export enum HEALTH_INFO_SUCCESS_MESSAGES {
   HEALTH_INFO_CREATED = 'Health info created successfully',
   HEALTH_INFO_UPDATED = 'Health info updated successfully',
   HEALTH_INFO_DELETED = 'Health info deleted successfully',
+  HEALTH_INFO_FETCHED = 'Health info fetched successfully',
 }

--- a/src/modules/health-info/dto/health-info.dto.ts
+++ b/src/modules/health-info/dto/health-info.dto.ts
@@ -122,3 +122,29 @@ export class UpdateHealthInfoDto {
   @IsString({ each: true })
   medicationsTaken?: string[];
 }
+
+export class FetchHealthInfoDto {
+  @ApiProperty({
+    description: 'The user identifier',
+    example: '1234567890',
+  })
+  @IsNotEmpty()
+  @IsString()
+  userId: string;
+
+  @ApiPropertyOptional({
+    description: 'The approval identifier for accessing health info',
+    example: 'approval-12345',
+  })
+  @IsOptional()
+  @IsString()
+  approvalId?: string;
+
+  @ApiPropertyOptional({
+    description: 'The specific health info identifier to fetch',
+    example: 'health-info-67890',
+  })
+  @IsOptional()
+  @IsString()
+  healthInfoId?: string;
+}

--- a/src/modules/health-info/interface/health-info.interface.ts
+++ b/src/modules/health-info/interface/health-info.interface.ts
@@ -24,3 +24,9 @@ export interface IUpdateHealthInfo {
   medicationsTaken?: string[];
   attachmentFilePath?: string;
 }
+
+export interface IFetchHealthInfo {
+  userId: string;
+  approvalId?: string;
+  healthInfoId?: string;
+}

--- a/src/modules/health-info/service/health-info.service.ts
+++ b/src/modules/health-info/service/health-info.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { HealthInfoProvider } from '../provider/health-info.provider';
 import {
   ICreateHealthInfo,
+  IFetchHealthInfo,
   IUpdateHealthInfo,
 } from '../interface/health-info.interface';
 
@@ -15,5 +16,9 @@ export class HealthInfoService {
 
   async updateHealthInfo(ctx: IUpdateHealthInfo) {
     return await this.healthInfoProvider.updateHealthInformation(ctx);
+  }
+
+  async fetchHealthInfo(ctx: IFetchHealthInfo) {
+    return await this.healthInfoProvider.fetchHealthInformation(ctx);
   }
 }


### PR DESCRIPTION
Exposed endpoint to fetch health info. 
`fetchHealthInfo`

>[!important] 
>_When fetching health information, supply `userId` when calling action as patient from dashboard. supply `healthInfoId` & `approvalId` when fetching patient health info as practitioner_
