### PR TITLE
Feat/User

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "neverthrow": "^8.2.0",
         "otpauth": "^9.4.0",
         "passport-google-oauth20": "^2.0.0",
+        "postmark": "^4.0.5",
         "redis": "^5.5.6",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
@@ -13513,6 +13514,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postmark": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/postmark/-/postmark-4.0.5.tgz",
+      "integrity": "sha512-nerZdd3TwOH4CgGboZnlUM/q7oZk0EqpZgJL+Y3Nup8kHeaukxouQ6JcFF3EJEijc4QbuNv1TefGhboAKtf/SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.7.4"
       }
     },
     "node_modules/prelude-ls": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "neverthrow": "^8.2.0",
     "otpauth": "^9.4.0",
     "passport-google-oauth20": "^2.0.0",
+    "postmark": "^4.0.5",
     "redis": "^5.5.6",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/src/modules/otp/otp.module.ts
+++ b/src/modules/otp/otp.module.ts
@@ -7,5 +7,6 @@ import { ErrorHandler } from '@/shared/error-handler/error.handler';
 @Module({
   providers: [OtpService, OtpProvider, ErrorHandler],
   controllers: [OtpController],
+  exports: [OtpService],
 })
 export class OtpModule {}

--- a/src/modules/user/data/user.data.ts
+++ b/src/modules/user/data/user.data.ts
@@ -11,6 +11,7 @@ export enum USER_ERROR_MESSAGES {
   ERROR_HANDLING_DOCTOR_REGISTRATION = 'Error handling doctor registration',
   ERROR_FETCHING_DASHBOARD_DATA = 'Error fetching dashboard data',
   DASHBOARD_DATA_NOT_IMPLEMENTED = 'Dashboard data not implemented for this role',
+  ERROR_SENDING_EMAIL = 'Error sending otp',
 }
 
 export enum USER_SUCCESS_MESSAGE {
@@ -19,4 +20,5 @@ export enum USER_SUCCESS_MESSAGE {
   USER_DELETED_SUCCESSFULLY = 'User deleted successfully',
   USER_UPDATED = 'User updated successfully',
   SUCCESS_FETCHING_DASHBOARD_DATA = 'Dashboard data fetched successfully',
+  SUCCESS_SENDING_OTP = 'OTP sent successfully',
 }

--- a/src/modules/user/dto/user.dto.ts
+++ b/src/modules/user/dto/user.dto.ts
@@ -303,3 +303,13 @@ export class UpdateUserDto {
   @IsString()
   locationOfHospital?: string;
 }
+
+export class ResendOtpDto {
+  @ApiProperty({
+    description: 'The email address to resend OTP to',
+    example: 'john.doe@example.com',
+  })
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+}

--- a/src/modules/user/service/user.service.ts
+++ b/src/modules/user/service/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
-import { EOnUserLogin } from '@/shared/dtos/event.dto';
+import { EOnUserLogin, ESendOtp } from '@/shared/dtos/event.dto';
 import { SharedEvents } from '@/shared/events/shared.events';
 import { ICreateUser, IUpdateUser } from '../interface/user.interface';
 import { UserProvider } from '../provider/user.provider';
@@ -32,5 +32,9 @@ export class UserService {
 
   async fetchDashboardData(userId: string) {
     return await this.userProvider.fetchDashboardData(userId);
+  }
+
+  async resendOtp(ctx: ESendOtp) {
+    return await this.userProvider.sendOtp(ctx);
   }
 }

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -10,6 +10,8 @@ import { UserService } from './service/user.service';
 import { WalletModule } from '../wallet/wallet.module';
 import { ApprovalModule } from '../approval/approval.module';
 import { ContractModule } from '../contract/contract.module';
+import { OtpModule } from '../otp/otp.module';
+import { PostmarkModule } from '@/shared/modules/postmark/postmark.module';
 
 @Module({
   imports: [
@@ -19,6 +21,8 @@ import { ContractModule } from '../contract/contract.module';
     forwardRef(() => WalletModule),
     forwardRef(() => ApprovalModule),
     forwardRef(() => ContractModule),
+    forwardRef(() => OtpModule),
+    forwardRef(() => PostmarkModule),
   ],
   providers: [UserProvider, UserService, AuthUtils, ErrorHandler],
   controllers: [UserController],

--- a/src/shared/dtos/event.dto.ts
+++ b/src/shared/dtos/event.dto.ts
@@ -126,3 +126,7 @@ export class EAddMedicalRecordToContract {
 export class EDeleteApproval {
   constructor(readonly approvalId: string) {}
 }
+
+export class ESendOtp {
+  constructor(readonly email: string) {}
+}

--- a/src/shared/events/shared.events.ts
+++ b/src/shared/events/shared.events.ts
@@ -15,4 +15,5 @@ export enum SharedEvents {
   MINT_HEALTH_TOKEN = 'mint.health.token',
   BATCH_MINT_HEALTH_TOKEN = 'batch.mint.health.token',
   TASK_COMPLETED = 'task.completed',
+  SEND_OTP = 'send.otp',
 }

--- a/src/shared/modules/postmark/data/postmark.data.ts
+++ b/src/shared/modules/postmark/data/postmark.data.ts
@@ -1,0 +1,12 @@
+export enum POSTMARK_ERROR_MESSAGES {
+  ERROR_SENDING_EMAIL = 'Error sending email',
+}
+
+export enum EMAIL_CONFIG {
+  FROM = 'support@allofhealth.africa',
+  SUBJECT = 'Verification',
+}
+
+export enum POSTMAN_SUCCESS_MESSAGES {
+  SUCCESS_SENDING_EMAIL = 'Email sent successfully',
+}

--- a/src/shared/modules/postmark/interface/postmark.interface.ts
+++ b/src/shared/modules/postmark/interface/postmark.interface.ts
@@ -1,1 +1,4 @@
-export interface Postmark {}
+export interface ISendEmail {
+  to: string;
+  body: string;
+}

--- a/src/shared/modules/postmark/postmark.module.ts
+++ b/src/shared/modules/postmark/postmark.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { PostmarkProvider } from './provider/postmark.provider';
 import { PostmarkService } from './service/postmark.service';
+import { ErrorHandler } from '@/shared/error-handler/error.handler';
 
 @Module({
-  providers: [PostmarkProvider, PostmarkService],
+  providers: [PostmarkProvider, PostmarkService, ErrorHandler],
 })
 export class PostmarkModule {}

--- a/src/shared/modules/postmark/postmark.module.ts
+++ b/src/shared/modules/postmark/postmark.module.ts
@@ -5,5 +5,6 @@ import { ErrorHandler } from '@/shared/error-handler/error.handler';
 
 @Module({
   providers: [PostmarkProvider, PostmarkService, ErrorHandler],
+  exports: [PostmarkService],
 })
 export class PostmarkModule {}

--- a/src/shared/modules/postmark/provider/postmark.provider.ts
+++ b/src/shared/modules/postmark/provider/postmark.provider.ts
@@ -1,7 +1,58 @@
 import { PostmarkConfig } from '@/shared/config/postmark/postmark.config';
-import { Injectable } from '@nestjs/common';
+import { ErrorHandler } from '@/shared/error-handler/error.handler';
+import { HttpStatus, Injectable } from '@nestjs/common';
+import { ServerClient } from 'postmark';
+import { ISendEmail } from '../interface/postmark.interface';
+import {
+  EMAIL_CONFIG,
+  POSTMARK_ERROR_MESSAGES as PEM,
+  POSTMAN_SUCCESS_MESSAGES as PSM,
+} from '../data/postmark.data';
+import { MyLoggerService } from '@/modules/my-logger/service/my-logger.service';
 
 @Injectable()
 export class PostmarkProvider {
-  constructor(private readonly postmarkConfig: PostmarkConfig) {}
+  private readonly logger = new MyLoggerService(PostmarkProvider.name);
+  constructor(
+    private readonly postmarkConfig: PostmarkConfig,
+    private readonly handler: ErrorHandler,
+  ) {}
+
+  private provideClient() {
+    return new ServerClient(this.postmarkConfig.SERVER_TOKEN);
+  }
+
+  async sendEmail(ctx: ISendEmail) {
+    const { to, body } = ctx;
+    try {
+      const client = this.provideClient();
+      const result = await client.sendEmail({
+        From: EMAIL_CONFIG.FROM,
+        To: to,
+        Subject: EMAIL_CONFIG.SUBJECT,
+        TextBody: body,
+      });
+
+      if (!result.MessageID) {
+        this.logger.debug(
+          `Failed to send email, please check the postmark server`,
+        );
+        return this.handler.handleReturn({
+          status: HttpStatus.BAD_REQUEST,
+          message: PEM.ERROR_SENDING_EMAIL,
+        });
+      }
+
+      return this.handler.handleReturn({
+        status: HttpStatus.OK,
+        message: PSM.SUCCESS_SENDING_EMAIL,
+        data: {
+          id: result.MessageID,
+          timestamp: result.SubmittedAt,
+        },
+      });
+    } catch (e) {
+      return this.handler.handleError(e, PEM.ERROR_SENDING_EMAIL);
+    }
+  }
 }

--- a/src/shared/modules/postmark/service/postmark.service.ts
+++ b/src/shared/modules/postmark/service/postmark.service.ts
@@ -1,4 +1,12 @@
 import { Injectable } from '@nestjs/common';
+import { PostmarkProvider } from '../provider/postmark.provider';
+import { ISendEmail } from '../interface/postmark.interface';
 
 @Injectable()
-export class PostmarkService {}
+export class PostmarkService {
+  constructor(private readonly postmarkProvider: PostmarkProvider) {}
+
+  async sendEmail(ctx: ISendEmail) {
+    return await this.postmarkProvider.sendEmail(ctx);
+  }
+}


### PR DESCRIPTION
this update integrates the `otp` module with the `user` module. users now get `otp` on sign up and can be validated at `/api/otp/verifyOtp`
>[!Important] 
_if otp delivery does not happen automatically on `signUp`, you can use the `resendOtp` endpoint at `/api/user/resendOtp`. verification is required to be done within a 2 min window_