### PR TITLE
fix(approval.provider.ts): default status query is created

### DIFF
--- a/src/modules/approval/provider/approval.provider.ts
+++ b/src/modules/approval/provider/approval.provider.ts
@@ -298,7 +298,7 @@ export class ApprovalProvider {
   }
 
   async fetchDoctorApprovals(ctx: IFetchDoctorApprovals) {
-    const { userId, page = 1, limit = 12, status = 'PENDING' } = ctx;
+    const { userId, page = 1, limit = 12, status = 'CREATED' } = ctx;
     const skip = (page - 1) * limit;
     try {
       const isCompliant = await this.practitionerCompliance(userId);


### PR DESCRIPTION
>[!Note]
Fix default `status`. 