### PR TITLE
Add SuspensionGuard to protect routes for suspended users

### DIFF
--- a/src/modules/approval/controller/approval.controller.ts
+++ b/src/modules/approval/controller/approval.controller.ts
@@ -37,6 +37,7 @@ import {
   RejectApprovalDto,
 } from '../dto/approval.dto';
 import { ApprovalService } from '../service/approval.service';
+import { SuspensionGuard } from '@/modules/auth/guards/suspension.guard';
 
 @ApiTags('Approval Operations')
 @Controller('approval')
@@ -45,7 +46,7 @@ export class ApprovalController {
   constructor(private readonly approvalService: ApprovalService) {}
 
   @Post('createApproval')
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({
     summary: 'Create new approvals',
     description:
@@ -173,7 +174,7 @@ export class ApprovalController {
   }
 
   @Get('fetchDoctorApprovals')
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({ summary: 'Fetch approvals for a doctor' })
   @ApiOkResponse({
     description: ASM.APPROVAL_FETCHED,
@@ -223,7 +224,7 @@ export class ApprovalController {
   }
 
   @Get('fetchPatientApprovals')
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({
     summary: 'Fetch approvals for a patient',
     description:
@@ -295,7 +296,7 @@ export class ApprovalController {
   }
 
   @Get('fetchApprovedApprovals')
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({
     summary: 'Fetch approved approvals for a user',
     description:
@@ -356,7 +357,7 @@ export class ApprovalController {
   }
 
   @Post('acceptApproval')
-  @UseGuards(AuthGuard)
+  @UseGuards(AuthGuard, SuspensionGuard)
   @ApiOperation({ summary: 'Accept an approval request' })
   @ApiOkResponse({
     description: ASM.APPROVAL_ACCEPTED,
@@ -401,7 +402,7 @@ export class ApprovalController {
   }
 
   @Post('rejectApproval')
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({ summary: 'Reject an approval request' })
   @ApiOkResponse({
     description: ASM.APPROVAL_REJECTED,
@@ -446,7 +447,7 @@ export class ApprovalController {
   }
 
   @Get('findApproval')
-  @UseGuards(AuthGuard)
+  @UseGuards(AuthGuard, SuspensionGuard)
   @ApiOperation({
     summary: 'Find an approval by ID',
     description:

--- a/src/modules/auth/guards/suspension.guard.ts
+++ b/src/modules/auth/guards/suspension.guard.ts
@@ -1,0 +1,88 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  HttpStatus,
+  Inject,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { MyLoggerService } from '@/modules/my-logger/service/my-logger.service';
+import { DRIZZLE_PROVIDER } from '@/shared/drizzle/drizzle.provider';
+import { Database } from '@/shared/drizzle/drizzle.types';
+import * as schema from '@/schemas/schema';
+import { eq } from 'drizzle-orm';
+import { UserError } from '@/modules/user/error/user.error';
+import { USER_STATUS } from '@/modules/user/data/user.data';
+
+@Injectable()
+export class SuspensionGuard implements CanActivate {
+  constructor(
+    @Inject(DRIZZLE_PROVIDER) private readonly db: Database,
+    private readonly jwtService: JwtService,
+    private readonly logger: MyLoggerService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+
+    const token = this.extractToken(request);
+
+    if (!token) {
+      throw new UnauthorizedException('No authorization token provided');
+    }
+
+    try {
+      const payload = await this.jwtService.verify(token);
+      const userId = payload.userId;
+      const status = await this.db
+        .select({
+          status: schema.user.status,
+        })
+        .from(schema.user)
+        .where(eq(schema.user.id, userId));
+
+      if (!status || status.length === 0) {
+        throw new NotFoundException(
+          new UserError('User not found', HttpStatus.NOT_FOUND),
+        );
+      }
+
+      const userStatus = status[0].status;
+      if (userStatus === USER_STATUS.SUSPENDED) {
+        throw new ForbiddenException('User is suspended');
+      }
+
+      return true;
+    } catch (error) {
+      this.logger.error(`Authentication error: ${error.message}`);
+
+      if (error.name === 'TokenExpiredError') {
+        throw new UnauthorizedException('Access token has expired');
+      }
+      if (error.name === 'JsonWebTokenError') {
+        throw new UnauthorizedException('Invalid token signature');
+      }
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
+
+      throw new UnauthorizedException('Authentication failed');
+    }
+  }
+
+  private extractToken(request: Request): string | undefined {
+    // @ts-expect-error authorization key will be added to the request header
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader) {
+      return;
+    }
+
+    const [type, token] = authHeader.split(' ');
+
+    return type === 'Bearer' ? token : undefined;
+  }
+}

--- a/src/modules/contract/dto/contract.dto.ts
+++ b/src/modules/contract/dto/contract.dto.ts
@@ -1,4 +1,10 @@
-import { IsNotEmpty, IsNumber, IsString, IsUUID } from 'class-validator';
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
 
 export class IsApprovedToAddRecordDto {
   @IsNotEmpty()
@@ -19,7 +25,7 @@ export class ViewMedicalRecordDto {
   @IsNumber()
   recordId: number;
 
-  @IsNotEmpty()
+  @IsOptional()
   @IsString()
   viewerAddress: string;
 }

--- a/src/modules/daily-tasks/controller/daily-tasks.controller.ts
+++ b/src/modules/daily-tasks/controller/daily-tasks.controller.ts
@@ -26,6 +26,7 @@ import {
   TaskStatsResponseDto,
 } from '../dto/daily-tasks.dto';
 import { DailyTasksService } from '../service/daily-tasks.service';
+import { SuspensionGuard } from '@/modules/auth/guards/suspension.guard';
 
 @ApiTags('Daily Tasks Operations')
 @Controller('daily-tasks')
@@ -58,7 +59,7 @@ export class DailyTasksController {
   }
 
   @Get('userDailyTasks')
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({
     summary: 'Get user daily tasks',
     description:
@@ -95,7 +96,7 @@ export class DailyTasksController {
   }
 
   @Post('completeDailyTask')
-  @UseGuards(AuthGuard, AdminGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, AdminGuard)
   @ApiOperation({
     summary: 'Complete a daily task',
     description:
@@ -119,7 +120,7 @@ export class DailyTasksController {
   }
 
   @Get('userDailyStats')
-  @UseGuards(AuthGuard, AdminGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, AdminGuard)
   @ApiOperation({
     summary: 'Get task statistics',
     description:

--- a/src/modules/health-info/controller/health-info.controller.ts
+++ b/src/modules/health-info/controller/health-info.controller.ts
@@ -38,6 +38,7 @@ import {
 } from '../dto/health-info.dto';
 import { HealthInfoService } from '../service/health-info.service';
 import { OwnerGuard } from '@/modules/user/guard/user.guard';
+import { SuspensionGuard } from '@/modules/auth/guards/suspension.guard';
 
 @ApiTags('Health Information Operations')
 @Controller('health-info')
@@ -62,7 +63,7 @@ export class HealthInfoController {
       }),
     }),
   )
-  @UseGuards(AuthGuard)
+  @UseGuards(AuthGuard, SuspensionGuard)
   @ApiOperation({
     summary: 'Create health information',
     description:
@@ -172,7 +173,7 @@ export class HealthInfoController {
       }),
     }),
   )
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({
     summary: 'Update health information',
     description:
@@ -275,7 +276,7 @@ export class HealthInfoController {
   }
 
   @Get('fetchHealthInfo')
-  @UseGuards(AuthGuard)
+  @UseGuards(AuthGuard, SuspensionGuard)
   @ApiOperation({
     summary: 'Fetch health information',
     description:

--- a/src/modules/health-journal/controller/health-journal.controller.ts
+++ b/src/modules/health-journal/controller/health-journal.controller.ts
@@ -26,6 +26,7 @@ import {
 } from '../data/health-journal.data';
 import { ErrorResponseDto, SuccessResponseDto } from '@/shared/dtos/shared.dto';
 import { TDuration } from '../interface/health-journal.interface';
+import { SuspensionGuard } from '@/modules/auth/guards/suspension.guard';
 
 @ApiTags('Journal Operations')
 @Controller('health-journal')
@@ -34,7 +35,7 @@ export class HealthJournalController {
   constructor(private readonly journalService: HealthJournalService) {}
 
   @Post('addJournalEntry')
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({ summary: 'Add a journal entry' })
   @ApiOkResponse({
     description: HSM.SUCCESS_ADDING_ENTRY,
@@ -58,7 +59,7 @@ export class HealthJournalController {
   }
 
   @Get('fetchUserJournals')
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({ summary: 'Fetch user journals' })
   @ApiOkResponse({
     description: HSM.SUCCESS_FETCHING_JOURNAL,
@@ -108,7 +109,7 @@ export class HealthJournalController {
   }
 
   @Get('fetchJournalMetrics')
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({
     summary: 'Fetch health journal metrics',
     description:

--- a/src/modules/user/controller/user.controller.ts
+++ b/src/modules/user/controller/user.controller.ts
@@ -41,6 +41,7 @@ import { UserError } from '../error/user.error';
 import { OwnerGuard } from '../guard/user.guard';
 import { UserService } from '../service/user.service';
 import { ESendOtp } from '@/shared/dtos/event.dto';
+import { SuspensionGuard } from '@/modules/auth/guards/suspension.guard';
 
 @ApiTags('User Operations')
 @Controller('user')
@@ -49,7 +50,7 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Get('dashboard')
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({
     summary: 'Fetch user dashboard data',
     description:
@@ -178,7 +179,7 @@ export class UserController {
       }),
     }),
   )
-  @UseGuards(AuthGuard, OwnerGuard)
+  @UseGuards(AuthGuard, SuspensionGuard, OwnerGuard)
   @ApiOperation({ summary: 'Updates an existing user' })
   @ApiConsumes('multipart/form-data')
   @ApiBody({


### PR DESCRIPTION
Introduce SuspensionGuard to prevent suspended users from accessing
protected endpoints across approval, daily-tasks, health-info,
health-journal, and user modules. Update relevant controllers to use
this guard. Also, make viewerAddress optional in ViewMedicalRecordDto.
